### PR TITLE
fix: do not render query methods in `Do` method if no fields

### DIFF
--- a/cmd/requestgen/main.go
+++ b/cmd/requestgen/main.go
@@ -169,7 +169,10 @@ type Generator struct {
 	receiverName   string
 
 	// the collected fields
-	fields      []Field
+	// fields is for post body
+	fields []Field
+
+	// queryFields means query string
 	queryFields []Field
 }
 
@@ -792,13 +795,18 @@ func ({{- .ReceiverName }} {{ typeString .StructType -}}) Do(ctx context.Context
 		return nil, err
 	}
 {{- else }}
+  // empty params for GET operation
 	var params interface{}
 {{- end }}
 
+{{- if .HasQueryParameters }}
 	query, err := {{ $recv }}.GetQueryParameters()
 	if err != nil {
 		return nil, err
 	}
+{{- else }}
+  query := url.Values{}
+{{- end }}
 
 	req, err := {{ $recv }}.{{ .ApiClientField }}.NewRequest("{{ .ApiMethod }}", "{{ .ApiUrl }}", query, params)
 	if err != nil {
@@ -825,6 +833,7 @@ func ({{- .ReceiverName }} {{ typeString .StructType -}}) Do(ctx context.Context
 			ApiMethod        string
 			ApiUrl           string
 			ResponseTypeName string
+			HasQueryParameters bool
 		}{
 			StructType:       g.structType,
 			ReceiverName:     g.receiverName,
@@ -832,6 +841,7 @@ func ({{- .ReceiverName }} {{ typeString .StructType -}}) Do(ctx context.Context
 			ApiMethod:        *apiMethodStr,
 			ApiUrl:           *apiUrlStr,
 			ResponseTypeName: *responseType,
+			HasQueryParameters:    len(g.queryFields) > 0,
 		})
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
input:
```go
//go:generate requestgen -type TestRequest -method GET -url /testpath
type TestRequest struct {
	client requestgen.APIClient
}
```

output
```go
func (p *Client) Do(ctx context.Context) (interface{}, error) {

	// empty params for GET operation
	var params interface{}
	query := url.Values{}

	req, err := p.client.NewRequest("GET", "/testpath", query, params)
	if err != nil {
		return nil, err
	}

	response, err := p.client.SendRequest(req)
	if err != nil {
		return nil, err
	}

	var apiResponse interface{}
	if err := response.DecodeJSON(&apiResponse); err != nil {
		return nil, err
	}

	return &apiResponse, nil
}

```
