### PR TITLE
fix: add missing ctx

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ interface (defined in `requestgen.APIClient`)
 // APIClient defines the request builder method and request method for the API service
 type APIClient interface {
 	// NewRequest builds up the http request for public endpoints
-	NewRequest(method, refURL string, params url.Values, payload interface{}) (*http.Request, error)
+	NewRequest(ctx context.Context, method, refURL string, params url.Values, payload interface{}) (*http.Request, error)
 
 	// SendRequest sends the request object to the api gateway
 	SendRequest(req *http.Request) (*Response, error)

--- a/client.go
+++ b/client.go
@@ -1,19 +1,20 @@
 package requestgen
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 )
 
 type AuthenticatedRequestBuilder interface {
 	// NewAuthenticatedRequest builds up the http request for authentication-required endpoints
-	NewAuthenticatedRequest(method, refURL string, params url.Values, payload interface{}) (*http.Request, error)
+	NewAuthenticatedRequest(ctx context.Context, method, refURL string, params url.Values, payload interface{}) (*http.Request, error)
 }
 
 // APIClient defines the request builder method and request method for the API service
 type APIClient interface {
 	// NewRequest builds up the http request for public endpoints
-	NewRequest(method, refURL string, params url.Values, payload interface{}) (*http.Request, error)
+	NewRequest(ctx context.Context, method, refURL string, params url.Values, payload interface{}) (*http.Request, error)
 
 	// SendRequest sends the request object to the api gateway
 	SendRequest(req *http.Request) (*Response, error)

--- a/cmd/requestgen/main.go
+++ b/cmd/requestgen/main.go
@@ -531,7 +531,7 @@ func ({{- .ReceiverName }} * {{- typeString .StructType -}}) Do(ctx context.Cont
   query := url.Values{}
 {{- end }}
 
-	req, err := {{ $recv }}.{{ .ApiClientField }}.{{ $requestMethod }}("{{ .ApiMethod }}", "{{ .ApiUrl }}", query, params)
+	req, err := {{ $recv }}.{{ .ApiClientField }}.{{ $requestMethod }}(ctx, "{{ .ApiMethod }}", "{{ .ApiUrl }}", query, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We haven't use the ctx of `Do` method to create a new request. That's necessary for interrupt the request.